### PR TITLE
Fix view template parameter for assets_version

### DIFF
--- a/views/index.ecr
+++ b/views/index.ecr
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="shortcut icon" href="">
 
-    <link rel="stylesheet" href="/dist/application.css?v=#{assets_version}" async="async" defer="defer">
-    <script src="/dist/application.js?v=#{asset_version}" media="all"></script>
+    <link rel="stylesheet" href="/dist/application.css?v=<%= assets_version %>" async="async" defer="defer">
+    <script src="/dist/application.js?v=<%= assets_version %>" media="all"></script>
 
     <title>cryMPD</title>
   </head>


### PR DESCRIPTION
The original version used asset_version vs. assets_version, plus it didn't use ECR tags, so it did just output the string literally.
https://crystal-lang.org/api/1.4.1/ECR.html
